### PR TITLE
Dependency removal (fs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "events": "^1.1.0",
-    "fs": "0.0.2",
     "readline": "^1.2.1",
     "stream": "0.0.2"
   },


### PR DESCRIPTION
Heya, just a quickie-PR.  This package is a spam/placeholder package in npm which doesn't serve any purpose other than being an extra dependency.  The fs module is built-in so there is no need to explicitly add it to the dependency list.  There's more info on this here: https://www.npmjs.com/package/fs and here: http://status.npmjs.org/incidents/dw8cr1lwxkcr. :smiley: 
